### PR TITLE
Mechanical Plugin Update

### DIFF
--- a/MechanicalPlugin/mechanicalplugin.cpp
+++ b/MechanicalPlugin/mechanicalplugin.cpp
@@ -9,7 +9,7 @@ BAKKESMOD_PLUGIN(MechanicalPlugin, "Mechanical training plugin", "0.1", PLUGINTY
 
 template <typename T>
 T clip(const T& n, const T& lower, const T& upper) {
-	return std::max(lower, std::min(n, upper));
+	return max(lower, min(n, upper));
 }
 
 void MechanicalPlugin::onLoad()
@@ -44,12 +44,6 @@ void MechanicalPlugin::onLoad()
 	cvarManager->registerCvar("mech_disable_boost", "0", "Disables boost", true, true, 0.f, true, 1.f).bindTo(disableBoost);
 	cvarManager->registerCvar("mech_hold_boost", "0", "Holds boost", true, true, 0.f, true, 1.f).bindTo(holdBoost);
 	cvarManager->registerCvar("mech_hold_roll", "0", "Holds air roll", true, true, 0.f, true, 1.f).bindTo(holdRoll);
-	
-	/*gameWrapper->HookEventWithCaller<CarWrapper>("Function TAGame.Car_TA.SetVehicleInput",
-		bind(&MechanicalPlugin::OnPreAsync, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));*/
-
-	//gameWrapper->HookEventWithCallerPost<PlayerControllerWrapper >("Function TAGame.PlayerController_TA.PlayerMove", std::bind(&MechanicalPlugin::OnPreAsync, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-	// > HookEvent("Function TAGame.RBActor_TA.PreAsyncTick", bind(&MechanicalPlugin::OnPreAsync, this, _1));
 }
 
 void MechanicalPlugin::onUnload()
@@ -58,7 +52,6 @@ void MechanicalPlugin::onUnload()
 
 void MechanicalPlugin::OnPreAsync(CarWrapper cw, void * params, string funcName)
 {
-	//cvarManager->log("PreAsync");
 	if (gameWrapper->IsInFreeplay())
 	{
 		//cvarManager->log("PreAsync in tut");
@@ -108,8 +101,6 @@ void MechanicalPlugin::OnPreAsync(CarWrapper cw, void * params, string funcName)
 			ci->Pitch = clip(ci->Pitch, -abs(*limitPitch), abs(*limitPitch));
 			ci->Roll = clip(ci->Roll, -abs(*limitRoll), abs(*limitRoll));
 			//player.SetInput(ci);
-			
-		
 	}
 }
 
@@ -122,7 +113,7 @@ void MechanicalPlugin::OnFreeplayLoad(std::string eventName)
 
 void MechanicalPlugin::OnFreeplayDestroy(std::string eventName)
 {
-	gameWrapper->UnhookEvent("Function TAGame.RBActor_TA.PreAsyncTick");
+	gameWrapper->UnhookEvent("Function TAGame.Car_TA.SetVehicleInput");
 }
 
 void MechanicalPlugin::OnEnabledChanged(std::string oldValue, CVarWrapper cvar)
@@ -134,6 +125,6 @@ void MechanicalPlugin::OnEnabledChanged(std::string oldValue, CVarWrapper cvar)
 	}
 	else
 	{
-		gameWrapper->UnhookEvent("Function TAGame.RBActor_TA.PreAsyncTick");
+		gameWrapper->UnhookEvent("Function TAGame.Car_TA.SetVehicleInput");
 	}
 }

--- a/MechanicalPlugin/mechanicalplugin.cpp
+++ b/MechanicalPlugin/mechanicalplugin.cpp
@@ -25,6 +25,8 @@ void MechanicalPlugin::onLoad()
 	disableJump = make_shared<bool>(false);
 	disableBoost = make_shared<bool>(false);
 	holdBoost = make_shared<bool>(false);
+	holdRoll = make_shared<bool>(false);
+	
 	gameWrapper->HookEvent("Function TAGame.GameEvent_Tutorial_TA.OnInit", bind(&MechanicalPlugin::OnFreeplayLoad, this, std::placeholders::_1));
 	gameWrapper->HookEvent("Function TAGame.GameEvent_Tutorial_TA.Destroyed", bind(&MechanicalPlugin::OnFreeplayDestroy, this, std::placeholders::_1));
 
@@ -40,8 +42,9 @@ void MechanicalPlugin::onLoad()
 	cvarManager->registerCvar("mech_disable_handbrake", "0", "Disables handbrake", true, true, 0.f, true, 1.f).bindTo(disableHandbrake);
 	cvarManager->registerCvar("mech_disable_jump", "0", "Disables jump", true, true, 0.f, true, 1.f).bindTo(disableJump);
 	cvarManager->registerCvar("mech_disable_boost", "0", "Disables boost", true, true, 0.f, true, 1.f).bindTo(disableBoost);
-
 	cvarManager->registerCvar("mech_hold_boost", "0", "Holds boost", true, true, 0.f, true, 1.f).bindTo(holdBoost);
+	cvarManager->registerCvar("mech_hold_roll", "0", "Holds air roll", true, true, 0.f, true, 1.f).bindTo(holdRoll);
+	
 	/*gameWrapper->HookEventWithCaller<CarWrapper>("Function TAGame.Car_TA.SetVehicleInput",
 		bind(&MechanicalPlugin::OnPreAsync, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));*/
 
@@ -88,6 +91,15 @@ void MechanicalPlugin::OnPreAsync(CarWrapper cw, void * params, string funcName)
 				ci->ActivateBoost = true;
 				ci->HoldingBoost = true;
 				//cvarManager->log("blocked boost");
+			}
+		
+			if (*holdRoll)
+			{
+				//Controller input for air roll
+				//Change Yaw into Roll
+				ci->Roll = clip(ci->Yaw, -abs(*limitRoll), abs(*limitRoll));
+				ci->Yaw = 0
+				//cvarManager->log("blocked air roll");
 			}
 
 			ci->Steer = clip(ci->Steer, -abs(*limitSteer), abs(*limitSteer));

--- a/MechanicalPlugin/mechanicalplugin.h
+++ b/MechanicalPlugin/mechanicalplugin.h
@@ -15,6 +15,7 @@ private:
 	shared_ptr<bool> disableJump;
 	shared_ptr<bool> disableBoost;
 	shared_ptr<bool> holdBoost;
+	shared_ptr<bool> holdRoll;
 public:
 	virtual void onLoad();
 	virtual void onUnload();


### PR DESCRIPTION
Adds Hold Air Roll Functionality
Changes std::max and std::min to just max and min, as it didn't compile
Also change unhooking behavior from gameWrapper->UnhookEvent("Function TAGame.RBActor_TA.PreAsyncTick"); to gameWrapper->UnhookEvent("Function TAGame.Car_TA.SetVehicleInput"); as it didn't properly disable the plugin when "Enable Mechanical Plugin" was unchecked in the Plugin menu