### PR TITLE
RCON websocket restarting

### DIFF
--- a/RCONPlugin/RCONPlugin.cpp
+++ b/RCONPlugin/RCONPlugin.cpp
@@ -193,11 +193,11 @@ void RCONPlugin::onLoad()
 	cvarManager->registerNotifier("rcon_start_server", [this](std::vector<std::string> commands) {
 		ws_server.get_io_service().reset();
 		server_running_mutex.unlock();
-	}, "Start rcon server back up after being shutdown", PERMISSION_ALL);
+	}, "Start rcon server back up", PERMISSION_ALL);
 
 	cvarManager->registerNotifier("rcon_kill_server", [this](std::vector<std::string> commands) {
 		shutdown_server();
-	}, "Start rcon server back up after being shutdown", PERMISSION_ALL);
+	}, "Shutdown the rcon ws server", PERMISSION_ALL);
 
 	cvarManager->registerNotifier("rcon_restart_server", [this](std::vector<std::string> commands) {
 		//asio is async and frankely I have no idea how to check how long it takes. 

--- a/RCONPlugin/RCONPlugin.cpp
+++ b/RCONPlugin/RCONPlugin.cpp
@@ -191,8 +191,13 @@ void RCONPlugin::onLoad()
 	}, "Disconnects all rcon connections", PERMISSION_ALL);
 	
 	cvarManager->registerNotifier("rcon_start_server", [this](std::vector<std::string> commands) {
-		ws_server.get_io_service().reset();
-		server_running_mutex.unlock();
+		if (ws_server.is_listening()){
+			cvarManager->log("Server is already running");
+		}
+		else {
+			ws_server.get_io_service().reset();
+			server_running_mutex.unlock();
+		}
 	}, "Start rcon server back up", PERMISSION_ALL);
 
 	cvarManager->registerNotifier("rcon_kill_server", [this](std::vector<std::string> commands) {

--- a/RCONPlugin/RCONPlugin.cpp
+++ b/RCONPlugin/RCONPlugin.cpp
@@ -150,7 +150,7 @@ void RCONPlugin::onLoad()
 {
 	logRcon = std::make_shared<bool>(false);
 	cvarManager->registerCvar("rcon_password", "password");
-	cvarManager->registerCvar("rcon_port", "9002"); //Registered in the main dll now
+	//cvarManager->registerCvar("rcon_port", "9002"); //Registered in the main dll now
 	cvarManager->registerCvar("rcon_timeout", "5");
 	cvarManager->registerCvar("rcon_log", "0", "Log all incoming rcon commands", true, true, 0, true, 1, true).bindTo(logRcon);
 

--- a/RCONPlugin/RCONPlugin.cpp
+++ b/RCONPlugin/RCONPlugin.cpp
@@ -326,7 +326,6 @@ void RCONPlugin::shutdown_server() {
 void RCONPlugin::onUnload()
 {
 	shut_down = true;
-	// A full shutdown seems to crash so I just do this instead???
-	ws_server.get_io_service().stop();
 	server_running_mutex.unlock();
+	ws_server.stop();
 }

--- a/RCONPlugin/RCONPlugin.cpp
+++ b/RCONPlugin/RCONPlugin.cpp
@@ -126,6 +126,7 @@ void RCONPlugin::run_server()
 
 		// Listen on port 9002
 		int port = cvarManager->getCvar("rcon_port").getIntValue();
+		if (port == NULL) port = 9002;
 		ws_server.listen(port);
 
 		// Start the server accept loop

--- a/RCONPlugin/RCONPlugin.cpp
+++ b/RCONPlugin/RCONPlugin.cpp
@@ -73,7 +73,8 @@ void RCONPlugin::on_message(server* s, websocketpp::connection_hdl hdl, message_
 				//is_allowed
 				//Rebuild command
 				std::string payload = msg->get_payload();
-				replace(payload, "\"", "\\\"");
+				//Doesn't seem neccessary? words in "" come thru in payload and sendback ok
+				//replace(payload, "\"", "\\\"");
 				gameWrapper->Execute([cmd = payload, &_cvarManager = cvarManager, log = *logRcon](GameWrapper* gw) {
 					_cvarManager->executeCommand(cmd, log);
 				});

--- a/RCONPlugin/RCONPlugin.h
+++ b/RCONPlugin/RCONPlugin.h
@@ -7,7 +7,6 @@
 #include "websocketpp/config/asio_no_tls.hpp"
 #include "websocketpp/server.hpp"
 #include <regex>
-#include <thread>
 typedef websocketpp::server<websocketpp::config::asio> server;
 
 using websocketpp::lib::placeholders::_1;

--- a/RCONPlugin/RCONPlugin.h
+++ b/RCONPlugin/RCONPlugin.h
@@ -7,6 +7,7 @@
 #include "websocketpp/config/asio_no_tls.hpp"
 #include "websocketpp/server.hpp"
 #include <regex>
+#include <thread>
 typedef websocketpp::server<websocketpp::config::asio> server;
 
 using websocketpp::lib::placeholders::_1;
@@ -35,6 +36,7 @@ private:
 	std::shared_ptr<bool> logRcon;
 	std::map<connection_ptr, connection_data> auths;
 	std::mutex server_running_mutex;
+	bool shut_down = false;
 	server ws_server;
 	void on_message(server* s, websocketpp::connection_hdl hdl, message_ptr msg);
 
@@ -45,5 +47,6 @@ public:
 	virtual void onUnload();
 	bool is_authenticated(connection_ptr hdl);
 	void run_server();
+	void shutdown_server();
 };
 


### PR DESCRIPTION
I've done some basic testing and made sure the plugin loads/unloads repeatedly and safely as well as just hitting the commands several times in a row.  There are a few special circumstances that can cause crashes and I've listed my findings. 

I've added 4 notifiers:

- `rcon_start_server` If the ws server is not listenting it'll start it up the server

- `rcon_kill_server` if the ws server is listenting, it'll instruct it to stop/close connections

- `rcon_restart_server` this combines the above 2 commands (literally) and due to some troubles with ASIO, has an overly generous wait period of 1 second. 

- `rcon_wsstatus` reports back if the endpoint is listening and if it's a server type. 

**A few things to know; I failed to get _any way of spinning/idle_ so I opted the restart to use the sleep command.**
I'm sorta new to all of this and genuinely don't know how I'd asynchronously check ASIO to properly wait in this context. Spinning caused crashes and since I every time I tried to create a thread it crashed; semaphores or more mutexes weren't really available to me.  

SO, **_if you were to call kill and start immediately, it could crash to desktop_** due to ASIO asynchronicity needing time. Where that starts and finishes is unknown to me; I read thru websocketpp a tiny bit and didn't find much about ASIO itself. 

Additionally **_if you were to change ports and fire up a new server, you MUST kill it before unloading rcon._** Starting a new server, then unloading it, causes a crash. 